### PR TITLE
remove actions/cache step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,14 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go mod download
       - name: Test
         run: |
           go test -v -coverprofile=profile.cov ./...


### PR DESCRIPTION
actions/setup-go caches the Go dependency automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the workflow by reordering steps for code checkout and Go setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->